### PR TITLE
chore: move development dependencies into dev-depencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"eslint": "^7.7.0",
 		"moment": "^2.27.0",
 		"mysql": "^2.18.1",
-		"node-fetch": "^2.6.0",
+		"node-fetch": "^2.6.1",
 		"typescript": "^4.0.2"
 	},
 	"devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
 	"dependencies": {
 		"chalk": "^4.1.0",
 		"discord.js": "^12.3.1",
-		"eslint": "^7.7.0",
 		"moment": "^2.27.0",
 		"mysql": "^2.18.1",
 		"node-fetch": "^2.6.1",
@@ -17,7 +16,8 @@
 		"@types/node-fetch": "^2.5.7",
 		"@types/ws": "^7.2.6",
 		"@typescript-eslint/eslint-plugin": "^4.1.1",
-		"@typescript-eslint/parser": "^4.1.1"
+		"@typescript-eslint/parser": "^4.1.1",
+		"eslint": "^7.9.0"
 	},
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,6 @@
 	"description": "Sentinel Bot",
 	"main": "index.js",
 	"dependencies": {
-		"@types/mysql": "^2.15.15",
-		"@types/node-fetch": "^2.5.7",
-		"@types/ws": "^7.2.6",
-		"@typescript-eslint/eslint-plugin": "^3.9.1",
-		"@typescript-eslint/parser": "^3.9.1",
 		"chalk": "^4.1.0",
 		"discord.js": "^12.3.1",
 		"eslint": "^7.7.0",
@@ -17,7 +12,13 @@
 		"node-fetch": "^2.6.1",
 		"typescript": "^4.0.2"
 	},
-	"devDependencies": {},
+	"devDependencies": {
+		"@types/mysql": "^2.15.15",
+		"@types/node-fetch": "^2.5.7",
+		"@types/ws": "^7.2.6",
+		"@typescript-eslint/eslint-plugin": "^4.1.1",
+		"@typescript-eslint/parser": "^4.1.1"
+	},
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"build": "tsc && npm run start",


### PR DESCRIPTION
**Why should this PR be merged?**: 
This PR moves some dependencies into dev-dependencies as they are development-only dependencies

[Semantic Versioning Specification](https://semver.org/):
- [ ] This PR is a documentation-only change

- [ ] This PR changes the public interface in a backwards-compatible manner

- [ ] This PR changes the public interface in a non-backwards-compatible manner
