### PR TITLE
chore: bump discord.js to 12.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "index.js",
 	"dependencies": {
 		"chalk": "^4.1.0",
-		"discord.js": "^12.3.1",
+		"discord.js": "^12.4.1",
 		"moment": "^2.27.0",
 		"mysql": "^2.18.1",
 		"node-fetch": "^2.6.1",

--- a/src/util/BaseCommand.ts
+++ b/src/util/BaseCommand.ts
@@ -97,8 +97,8 @@ export function getSend(message: Message, command: Command) {
 		}
 		let response = message.lastCommand && message.lastCommand.response;
 		response = await (response
-			? response.edit(content, ...options)
-			: message.channel.send(content, ...options));
+			? response.edit(content, options[0])
+			: message.channel.send(content, ...options[0]));
 		message.setLastCommand(command, response);
 		return response;
 	}

--- a/src/util/BaseCommand.ts
+++ b/src/util/BaseCommand.ts
@@ -98,7 +98,7 @@ export function getSend(message: Message, command: Command) {
 		let response = message.lastCommand && message.lastCommand.response;
 		response = await (response
 			? response.edit(content, options[0])
-			: message.channel.send(content, ...options[0]));
+			: message.channel.send(content, options[0]));
 		message.setLastCommand(command, response);
 		return response;
 	}


### PR DESCRIPTION
**Why should this PR be merged?**: 
this PR bumps `discord.js` from 12.3.1 to 12.4.1

[Semantic Versioning Specification](https://semver.org/):
- [ ] This PR is a documentation-only change

- [x] This PR changes the public interface in a backwards-compatible manner

- [ ] This PR changes the public interface in a non-backwards-compatible manner
