### PR TITLE
fix(commands/lookup): correct selection bitfield

### DIFF
--- a/src/commands/general/lookup.ts
+++ b/src/commands/general/lookup.ts
@@ -20,7 +20,7 @@ export default class LookupCommand extends Command {
 		const ip = args[0];
 		if (!ip || !IP_REGEX.test(ip)) throw new CommandError('PROVIDE_IP');
      
-		const response = await fetch(URLs.IP_API(ip, 34809));
+		const response = await fetch(URLs.IP_API(ip, 59387));
 		if (response.status == 404) throw new CommandError('PROVIDE_IP');
 		const data = await response.json();
 		if (response.status !== 200) throw new CommandError('CUSTOM_MESSAGE', data.message || 'Unknown error');

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -354,8 +354,8 @@ export const CommandResponses = {
 		return new MessageEmbed()
 			.setColor(SentinelColors.LIGHT_BLUE)
 			.addFields({
-				name: 'Address',
-				value: data.query || 'Unknown',
+				name: 'Address' || 'Unknown',
+				value: data.query,
 				inline: true
 			}, {
 				name: 'ISP',
@@ -383,11 +383,11 @@ export const CommandResponses = {
 				inline: true
 			}, {
 				name: 'Latitude',
-				value: data.lat ?? 'Unknown',
+				value: data.lat || 'Unknown',
 				inline: true
 			}, {
-				name: '	Longitude',
-				value: data.lon ?? 'Unknown',
+				name: 'Longitude',
+				value: data.lon || 'Unknown',
 				inline: true
 			}, {
 				name: 'ORG',

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -354,8 +354,8 @@ export const CommandResponses = {
 		return new MessageEmbed()
 			.setColor(SentinelColors.LIGHT_BLUE)
 			.addFields({
-				name: 'Address' || 'Unknown',
-				value: data.query,
+				name: 'Address',
+				value: data.query || 'Unknown',
 				inline: true
 			}, {
 				name: 'ISP',


### PR DESCRIPTION
**Why should this PR be merged?**: 
This PR corrects the bitfield used to select fields from the IP lookup API

[Semantic Versioning Specification](https://semver.org/):
- [ ] This PR is a documentation-only change

- [X] This PR changes the public interface in a backwards-compatible manner

- [ ] This PR changes the public interface in a non-backwards-compatible manner
